### PR TITLE
Lock down ember-cli-sass dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-cli-sass": "^5.3.1"
+    "ember-cli-sass": "5.3.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Last night `ember-cli-sass` released version 5.5 which seems to be throwing an error when installing the addon. Related issue https://github.com/aexmachina/ember-cli-sass/issues/129.

This locks down `ember-cli-sass` version which should fix this for now
